### PR TITLE
More back-ticks and fix a grammar typo

### DIFF
--- a/docs/tutorials/args.md
+++ b/docs/tutorials/args.md
@@ -5,7 +5,7 @@
 
 ### The Problem
 
-A unfortunate fact about C++ functions is that arguments must be passed in a fixed order.
+An unfortunate fact about C++ functions is that arguments must be passed in a fixed order.
 This is frustrating when you are ok with certain default arguments, but must provide
 them anyway to reach arguments further down the list.
 
@@ -14,17 +14,17 @@ To make matters worse, function arguments can be opaque and hard to interpret.
 
     truncateMPS(psi,500,1E-5,false);
 
-While it is clear that psi is some matrix product state to be truncated, what do
+While it is clear that `psi` is some matrix product state to be truncated, what do
 the other parameters mean?
 
-If the truncateMPS function accepted an Args object instead, we
-could call it like this
+If the `truncateMPS` function accepted an `Args` object instead, we
+could call it like this:
 
     truncateMPS(psi,{"Maxm=",500,"Cutoff=",1E-9,"ShowSizes=",false});
 
 This is easier to read and lets us specify the parameters we care about,
 leaving the rest to have default values. For example, if we are happy with the default
-value for "Maxm" and "ShowSizes", we could call truncateMPS as
+value for `"Maxm"` and `"ShowSizes"`, we could call `truncateMPS` as
 
     truncateMPS(psi,{"Cutoff=",1E-9});
 
@@ -39,8 +39,8 @@ system. So the following call would have identical results
 
 Of course, in production code it is bad practice to "hard wire" numbers directly 
 into functions; a better practice is to define all parameters one place, like at 
-the top of main when reading from a parameter file. Even in this situation,
-the Args system makes things more readable and flexible
+the top of `main` when reading from a parameter file. Even in this situation,
+the `Args` system makes things more readable and flexible
 regarding argument order and default arguments:
 
     int maxm = 500;
@@ -52,7 +52,7 @@ regarding argument order and default arguments:
 <br/>
 ### Creating a Function that Accepts Args
 
-To allow a function to take an Args object, first make sure the Args class is available
+To allow a function to take an `Args` object, first make sure the `Args` class is available
 
     #include "itensor/util/args.h"
 
@@ -65,14 +65,14 @@ Next define the last argument of your function to be
     func(..., Args const& args = Args::global());
 
 where the "..." means all the usual arguments the function "func" accepts.
-For example, the truncateMPS function above could be declared as
+For example, the `truncateMPS` function above could be declared as
 
     MPS truncateMPS(MPS const& psi, Args const& args = Args::global());
 
 Making the default value `Args::global()` does the following: if no named arguments
-are passed then "args" will refer to the global Args object. By default the
-global Args object is empty;
-however, one can add arguments to Args::global() to set
+are passed then "args" will refer to the global `Args` object. By default the
+global `Args` object is empty;
+however, one can add arguments to `Args::global()` to set
 global defaults&mdash;for more details see the section on argument lookup order below.
 
 Sometimes you may want to further modify the args object within your function.
@@ -83,11 +83,11 @@ For such cases it is better to accept args by value
 <br/>
 ### Accessing Named Arguments Within a Function
 
-Using the fictitious truncateMPS function as an example, recall that it 
+Using the fictitious `truncateMPS` function as an example, recall that it 
 accepts three named arguments:
-* "Maxm" &mdash; an integer
-* "Cutoff" &mdash; a real number
-* "ShowSizes" &mdash; a boolean
+* `"Maxm"` &mdash; an integer
+* `"Cutoff"` &mdash; a real number
+* `"ShowSizes"` &mdash; a boolean
 
 (Named arguments can also be string valued.)
 
@@ -112,7 +112,7 @@ that will be used if that argument is not present in `args`. The
 order in which these functions are called is not important.
 
 Occasionally a named argument should be mandatory. To make it so, just
-leave out the default value when calling getInt, getReal, getBool, or getString:
+leave out the default value when calling `getInt`, `getReal`, `getBool`, or `getString`:
 
     void
     func(...
@@ -127,14 +127,14 @@ leave out the default value when calling getInt, getReal, getBool, or getString:
 <br/>
 ### Lookup Order and Global Args
 
-When calling one of the "get..." methods (such as getInt or getString) on an Args instance,
+When calling one of the "get..." methods (such as `getInt` or `getString`) on an `Args` instance,
 the value returned will be as follows:
 
 1. The value if defined in the instance itself
 
-2. If not defined in the instance, the value defined in the global Args object
+2. If not defined in the instance, the value defined in the global `Args` object
 
-3. If not defined in the global Args, the default value provided to "get..."
+3. If not defined in the global `Args`, the default value provided to "get..."
 
 Here is an example:
 
@@ -155,7 +155,7 @@ Here is an example:
 <br/>
 ### Creating Args Objects
 
-There are a few different ways to construct args objects. The simplest is the Args constructor,
+There are a few different ways to construct `Args` objects. The simplest is the `Args` constructor,
 which accepts any number of name-value pairs:
 
     auto args = Args("Name=","some_string",
@@ -172,7 +172,7 @@ So for example
 
     auto args = Args("Name=some_string,Size=200,Threshold=1E-10");
 
-Finally, arguments can be added to an Args object that is already defined using the add method.
+Finally, arguments can be added to an `Args` object that is already defined using the add method.
 Adding an argument that is already defined overwrites the previously defined value.
 
     auto args = Args("Name=","name1");


### PR DESCRIPTION
Should be "An unfortunate" rather than "A unfortunate".

Added a bunch of back-ticks to highlight C++ code objects.