### PR TITLE
Change installation instruction for ITensor V2 and V3

### DIFF
--- a/docs/cppv2/install/main.md
+++ b/docs/cppv2/install/main.md
@@ -2,14 +2,12 @@
 
 ## Downloading the Library
 
-The preferred method is to "clone" ITensor version 2 using the following commands:
+The preferred method is to "clone" ITensor version 2 using the following command:
 <div class="commandline"><pre>
 git clone https://github.com/ITensor/ITensor itensor
-cd itensor
-git checkout v2
 </pre></div>
 
-This allows you to track any updates to ITensor version 2 by just doing `git pull` in the ITensor folder.
+This allows you to track any updates to ITensor version 2 by just executing `git pull` in the `itensor` directory.
 If you do not have git on your computer, you can obtain it through your package manager or from the
 <a href="http://git-scm.com/" target="blank_">git website</a>.
 

--- a/docs/cppv2/install/main.md
+++ b/docs/cppv2/install/main.md
@@ -2,16 +2,16 @@
 
 ## Downloading the Library
 
-The preferred method is to "clone" the latest version of the library using the following command
+The preferred method is to "clone" ITensor version 2 using the following commands:
 <div class="commandline"><pre>
 git clone https://github.com/ITensor/ITensor itensor
+cd itensor
+git checkout v2
 </pre></div>
 
-This allows you to track any updates to ITensor by just doing `git pull` in the ITensor folder.
+This allows you to track any updates to ITensor version 2 by just doing `git pull` in the ITensor folder.
 If you do not have git on your computer, you can obtain it through your package manager or from the
 <a href="http://git-scm.com/" target="blank_">git website</a>.
-
-You can also download a zip file of the latest code by clicking <a href="https://github.com/ITensor/ITensor/zipball/master">this link</a>.
 
 ## Building the Library
 

--- a/docs/cppv3/install/main.md
+++ b/docs/cppv3/install/main.md
@@ -9,7 +9,7 @@ cd itensor
 git checkout rc3
 </pre></div>
 
-You can track any updates to ITensor version 3 by just doing `git pull` in the ITensor folder.
+You can track any updates to ITensor version 3 by just executing `git pull` in the `itensor` directory.
 If you do not have git on your computer, you can obtain it through your package manager or from the
 <a href="http://git-scm.com/" target="blank_">git website</a>.
 

--- a/docs/cppv3/install/main.md
+++ b/docs/cppv3/install/main.md
@@ -2,16 +2,16 @@
 
 ## Downloading the Library
 
-The preferred method is to "clone" the latest version of the library using the following command
+You can preview the unreleased ITensor version 3 by using the following commands:
 <div class="commandline"><pre>
 git clone https://github.com/ITensor/ITensor itensor
+cd itensor
+git checkout rc3
 </pre></div>
 
-This allows you to track any updates to ITensor by just doing `git pull` in the ITensor folder.
+You can track any updates to ITensor version 3 by just doing `git pull` in the ITensor folder.
 If you do not have git on your computer, you can obtain it through your package manager or from the
 <a href="http://git-scm.com/" target="blank_">git website</a>.
-
-You can also download a zip file of the latest code by clicking <a href="https://github.com/ITensor/ITensor/zipball/master">this link</a>.
 
 ## Building the Library
 

--- a/index.html
+++ b/index.html
@@ -101,7 +101,7 @@
     <li>Make sure you have an up-to-date C++11 compiler and LAPACK installed. On UNIX systems, use your
     package manager; on Mac OS install the free Xcode app from the app store;
     for Windows install <a href="https://www.cygwin.com" target="_blank">cygwin</a>.</li>
-    <li>Clone the latest version of ITensor: <pre><code>git clone https://github.com/ITensor/ITensor itensor; cd itensor; git checkout v2</code></pre>
+    <li>Clone the latest version of ITensor: <pre><code>git clone https://github.com/ITensor/ITensor itensor</code></pre>
         (Or <a href="https://github.com/ITensor/ITensor/zipball/master" target="_blank">download</a> the zip file if you do not have git.)<br/>
         Cloning with <a href="http://git-scm.com" target="_blank">git</a> allows you to track changes to ITensor and is the preferred method; for more see our <a href="docs.cgi?page=tutorials/git">git quick start</a> guide.
 

--- a/index.html
+++ b/index.html
@@ -46,7 +46,7 @@
         <h4>
         Latest version is <a href="docs.cgi?page=changelog#v2.1.1">v2.1.1</a>
         </h4>
-        <h4>Clone from <a target="_blank" href="https://github.com/ITensor/ITensor">github</a> (preferred)</h4>
+        <h4>Clone from <a target="_blank" href="http://www.itensor.org/docs.cgi?page=install&vers=cppv2">github</a> (preferred)</h4>
         <h4>Download: <a href="https://github.com/ITensor/ITensor/tarball/v2.1.1">tar.gz</a> or
                      <a href="https://github.com/ITensor/ITensor/zipball/v2.1.1">zip</a> </h4>
         <table style="padding:0;margin:0">
@@ -101,7 +101,7 @@
     <li>Make sure you have an up-to-date C++11 compiler and LAPACK installed. On UNIX systems, use your
     package manager; on Mac OS install the free Xcode app from the app store;
     for Windows install <a href="https://www.cygwin.com" target="_blank">cygwin</a>.</li>
-    <li>Clone the latest version of ITensor: <pre><code>git clone https://github.com/ITensor/ITensor itensor</code></pre>
+    <li>Clone the latest version of ITensor: <pre><code>git clone https://github.com/ITensor/ITensor itensor; cd itensor; git checkout v2</code></pre>
         (Or <a href="https://github.com/ITensor/ITensor/zipball/master" target="_blank">download</a> the zip file if you do not have git.)<br/>
         Cloning with <a href="http://git-scm.com" target="_blank">git</a> allows you to track changes to ITensor and is the preferred method; for more see our <a href="docs.cgi?page=tutorials/git">git quick start</a> guide.
 


### PR DESCRIPTION
Here are some clarifications on the preferred methods for installing ITensor V2 and V3.

The idea now is that the latest official ITensor V2 we want people to install is in the branch "v2", so we instruct people to checkout that branch. This will free up the master branch to eventually be used for something else.

Then, the instructions to try out ITensor V3 are to checkout the branch "rc3". 

Once we officially release ITensor V3, we will change "rc3" to "v3", and instruct people to checkout the "v3" branch. The branch "v3" will be the latest official release with bug fixes, and then we can have a different "v3dev" branch (or just use "master") with bleeding-edge changes to ITensor V3.

Does this development plan seem reasonable?