### PR TITLE
Adding reference to iterInds() to ITensor class documentation.

### DIFF
--- a/docs/cppv2/classes/itensor.md
+++ b/docs/cppv2/classes/itensor.md
@@ -604,7 +604,14 @@ and that the result will be an ITensor.
   In the `printfln` command, the `%s` formatting token 
   does not display ITensor elements, whereas the `%f` token
   shows all non-zero elements.
+
+* To iterate over all non-zero elements of an ITensor `T`, use `iterInds(T)` to obtain an
+  iterator returning a `std::vector<IndexVal>` for each non-zero element. The order of the
+  `IndexVal` obtained in the vectors will follow the same internal order of indices in the tensor.
   
+  This can be helpful when dealing with tensor slices or other structural manipulations of tensors
+  when paired with `.set()`, `.real()`, `.cplx()`, which take such vectors as arguments.
+
 ## Functions for Creating ITensors
 
 * `randomTensor(Index i1, Index i2, ...)` <br/>


### PR DESCRIPTION
Making sure docs are up to date, referencing the new iterInds(ITensor) feature.

**Note**: Please, also update the "current as of version" line as appropriate. I opted to not change it just in case I'm unaware of some lack of coverage.