### PR TITLE
Add iDMRG repo to codes page

### DIFF
--- a/docs/cppv3/codes.md
+++ b/docs/cppv3/codes.md
@@ -6,7 +6,9 @@ If you have a high-quality code you'd like listed here, please
 <a href="about.html">contact us</a>. Codes extending core ITensor
 features may become candidates for inclusion in ITensor at a later date.
 
-(Codes listed here are maintained separately from ITensor by the maintainers
+(Codes listed as maintained by "ITensor" are officially maintained by the developers
+of the ITensor library and will be tested against and updated along with the ITensor library.
+Other codes are maintained separately from ITensor by the maintainers
 shown next to each code. Please contact them directly if you have any issues 
 with or questions about the codes.)
 
@@ -24,6 +26,19 @@ Name
 </td>
 <td class="descrip">
 <b>Description</b>
+</td>
+</tr>
+
+<tr>
+<td class="name">
+<a href="https://github.com/ITensor/iDMRG" target="_blank">iDMRG</a>
+</td>
+<td class="contrib">
+ITensor
+</td>
+<td class="descrip">
+A single header file for idmrg calculations based on the ITensor library,
+with example driver codes.
 </td>
 </tr>
 


### PR DESCRIPTION
I'll leave this open until we decide to go ahead with removing iDMRG from the main ITensor library.