### PR TITLE
Add print_macro.h to examples

### DIFF
--- a/docs/cppv3/book/itensor_factorizing.md
+++ b/docs/cppv3/book/itensor_factorizing.md
@@ -61,6 +61,7 @@ product `U*S*V` gives us back an ITensor identical to T:
 <div class="example_clicker">Click here to view a full working example</div>
 
     #include "itensor/all.h"
+    #include "itensor/util/print_macro.h"
     using namespace itensor;
 
     int main() 

--- a/docs/cppv3/book/qn.md
+++ b/docs/cppv3/book/qn.md
@@ -72,7 +72,7 @@ Another example would be `QN({"Sz",1},{"T",2,3})` which defines a quantum number
 "Sz" with value 1 obeying usual integer arithmetic, whereas the quantum number named
 "T" has value 2 and obeys a @@Z_3@@ addition rule.
 
-## Advanced, Experimental Features
+## Advanced / Experimental Features
 
 Currently we are exploring a feature which would allow QN Indices to anticommute
 to give QN ITensors fermionic behavior, without requiring users to do any 

--- a/docs/cppv3/book/trg.cc
+++ b/docs/cppv3/book/trg.cc
@@ -1,5 +1,5 @@
 #include "itensor/all.h"
-
+#include "itensor/util/print_macro.h"
 using namespace itensor;
 
 int main()

--- a/docs/cppv3/book/trg.md
+++ b/docs/cppv3/book/trg.md
@@ -163,6 +163,7 @@ but let's look at each piece step by step.
 To get started, start with the following empty application:
 
     #include "itensor/all.h"
+    #include "itensor/util/print_macro.h"
 
     using namespace itensor;
 

--- a/docs/cppv3/formulas/itensor_single_site_op.md
+++ b/docs/cppv3/formulas/itensor_single_site_op.md
@@ -60,6 +60,7 @@ Complete sample code:
 
 
     #include "itensor/all.h"
+    #include "itensor/util/print_macro.h"
 
     using namespace itensor;
     using std::string;

--- a/docs/cppv3/formulas/simple_ed/simple_ed.cc
+++ b/docs/cppv3/formulas/simple_ed/simple_ed.cc
@@ -1,4 +1,5 @@
 #include "itensor/all.h"
+#include "itensor/util/print_macro.h"
 
 using namespace itensor;
 

--- a/docs/cppv3/formulas/tevol_trotter/test.cc
+++ b/docs/cppv3/formulas/tevol_trotter/test.cc
@@ -1,4 +1,5 @@
 #include "itensor/all.h"
+#include "itensor/util/print_macro.h"
 
 using namespace itensor;
 

--- a/docs/cppv3/formulas/tevol_trotter/tevol_trotter.cc
+++ b/docs/cppv3/formulas/tevol_trotter/tevol_trotter.cc
@@ -1,4 +1,5 @@
 #include "itensor/all.h"
+#include "itensor/util/print_macro.h"
 
 using namespace itensor;
 using std::vector;


### PR DESCRIPTION
This pull request adds the use of itensor/util/print_macro.h to various example codes on the website, following the removal of this header from the itensor/all.h header (see issue 279 on the Github ITensor/ITensor repo).