### PR TITLE
Add citation information to front page

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,7 +136,7 @@
     <p>
     <b>Citing ITensor</b>
     <p>
-    Please cite ITensor if you use it to produce data or other results for a publication.
+    Please cite the ITensor paper if you use the C++ or Julia version to produce data or other results for a publication.
     You may use the following BibTex entry to cite in LaTeX documents:
     <div class="full screenshot">
     <pre>

--- a/index.html
+++ b/index.html
@@ -136,7 +136,7 @@
     <p>
     <b>Citing ITensor</b>
     <p>
-    Please cite the ITensor paper if you use the C++ or Julia version to produce data or other results for a publication.
+    Please cite the <a href="https://arxiv.org/abs/2007.14822">ITensor paper</a> if you use the C++ or Julia version to produce data or other results for a publication.
     You may use the following BibTex entry to cite in LaTeX documents:
     <div class="full screenshot">
     <pre>

--- a/index.html
+++ b/index.html
@@ -133,6 +133,26 @@
     Browse the <a href="docs.cgi?page=main&vers=cppv3">documentation pages</a> to learn more about ITensor.
     </p>
     
+    <p>
+    <b>Citing ITensor</b>
+    <p>
+    Please cite ITensor if you use it to produce data or other results for a publication.
+    You may use the following BibTex entry to cite in LaTeX documents:
+    <div class="full screenshot">
+    <pre>
+    @misc{itensor,
+        title={The \mbox{ITensor} Software Library for Tensor Network Calculations},
+        author={Matthew Fishman and Steven R. White and E. Miles Stoudenmire},
+        year={2020},
+        eprint={2007.14822},
+        archivePrefix={arXiv}
+    }
+    </pre>
+    </div>
+    </p>
+    </p>
+
+
 
     </p>
     <br/>


### PR DESCRIPTION
This adds instructions on citing ITensor to the front page (maybe there is a better place for it, or somewhere else we should put it as well). I noticed some of the recent papers weren't citing the paper, and it looks like that information was only in the news so it may be hard to find.

@emstoudenmire, I rendered `index.html` locally but I don't have it set up to build the entire website, could you test this to make sure it renders properly?