### PR TITLE
Add link to Julia docs for missing docs

### DIFF
--- a/gen_docs.py
+++ b/gen_docs.py
@@ -234,7 +234,7 @@ def generate():
         bodyhtml = convert("".join(mdfile.readlines()),vers,lang)
         mdfile.close()
     else:
-        bodyhtml = "<p>(Documentation file not found)</p>"
+        bodyhtml = "<p>(Documentation file not found)</p><p>If you are looking for documentation for the Julia version, in-depth documentation can be found <a href="https://itensor.github.io/ITensors.jl/stable/index.html">here</a></p>"
 
     # Generate directory tree hyperlinks
     dirlist = page.split('/')


### PR DESCRIPTION
@emstoudenmire I think this will be useful for people who see the "Missing documentation" message when they are on a C++ docs page and try to change to the Julia version of the same docs.

I'm not sure if this is working, I don't have it set up to test the docs locally right now...